### PR TITLE
Content extractor using Diffbot

### DIFF
--- a/talkpocket-api/project.clj
+++ b/talkpocket-api/project.clj
@@ -15,7 +15,9 @@
                  [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.21"]
                  [org.slf4j/jcl-over-slf4j "1.7.21"]
-                 [org.slf4j/log4j-over-slf4j "1.7.21"]]
+                 [org.slf4j/log4j-over-slf4j "1.7.21"]
+
+                 [diffbot/diffbot "0.1.0"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency
@@ -24,4 +26,3 @@
                    :dependencies [[io.pedestal/pedestal.service-tools "0.5.1"]]}
              :uberjar {:aot [talkpocket-api.server]}}
   :main ^{:skip-aot true} talkpocket-api.server)
-

--- a/talkpocket-api/src/talkpocket_api/extractor/feed_extractor.clj
+++ b/talkpocket-api/src/talkpocket_api/extractor/feed_extractor.clj
@@ -1,0 +1,13 @@
+(ns talkpocket-api.extractor.feed-extractor
+  (:require [diffbot.core :refer :all]))
+
+(def token (System/getenv "DIFFBOT_TOKEN"))
+
+(defn extract
+  "Extract article from URL"
+  [url]
+  (let [content (article token url)
+        text (:text content)
+        url (:url content)]
+    {:text text
+     :url url}))

--- a/talkpocket-api/src/talkpocket_api/service.clj
+++ b/talkpocket-api/src/talkpocket_api/service.clj
@@ -2,7 +2,9 @@
   (:require [io.pedestal.http :as http]
             [io.pedestal.http.route :as route]
             [io.pedestal.http.body-params :as body-params]
-            [ring.util.response :as ring-resp]))
+            [ring.util.response :as ring-resp]
+
+            [talkpocket-api.extractor.feed-extractor :as feed]))
 
 (defn about-page
   [request]
@@ -67,4 +69,3 @@
                                         ;:key-password "password"
                                         ;:ssl-port 8443
                                         :ssl? false}})
-


### PR DESCRIPTION
Using Diffbot, we extract article information that then will be feeded to
Watson. This is focusing only on passing text and url.

Currently we return:
- :text - Content regarded as important
- :url - URL related with said content

This will be used by core-async to feed next steps
